### PR TITLE
Mark generated topics

### DIFF
--- a/xslt/dita2html.xsl
+++ b/xslt/dita2html.xsl
@@ -40,6 +40,10 @@
       <xsl:value-of select="normalize-space($commit)"/>
       <xsl:text>"&#xA;</xsl:text>
     </xsl:if>
+    <xsl:if test="contains(/*/@outputclass, 'generated') or contains(/*/title[1]/@outputclass, 'generated')">
+      <xsl:text>generated: true</xsl:text>
+      <xsl:text>&#xA;</xsl:text>
+    </xsl:if>
     <xsl:text>---&#xA;</xsl:text>
   </xsl:template>
 


### PR DESCRIPTION
If the root or the title contain generated in the output class then generate "generated: true" in the metadata section for the result HTML. This will be useful to provide different content in a template for generated topics.
This will allow us to generate for example [Edit] links only in real topics, we can check for the `page.generated` metadata in the HTML template and decide if we add the link or not. 