### PR TITLE
Preserve page description metadata

### DIFF
--- a/xsl/dita2html.xsl
+++ b/xsl/dita2html.xsl
@@ -29,9 +29,17 @@
     <xsl:text>title: '</xsl:text>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="text-only"/>
     <xsl:text>'&#xA;</xsl:text>
-    <xsl:if test="*[contains(@class, ' topic/shortdesc ')]">
+    <xsl:variable name="shortdescs" as="element()*"
+                  select="*[contains(@class, ' topic/shortdesc ')] |
+                          *[contains(@class, ' topic/abstract ')]/*[contains(@class, ' topic/shortdesc ')]"/>
+    <xsl:if test="exists($shortdescs)">
       <xsl:text>description: '</xsl:text>
-      <xsl:apply-templates select="*[contains(@class, ' topic/shortdesc ')]" mode="text-only"/>
+      <xsl:for-each select="$shortdescs">
+        <xsl:if test="position() ne 1">
+          <xsl:text> </text>
+        </xsl:if>
+        <xsl:apply-templates select=". mode="text-only"/>
+      </xsl:for-each>
       <xsl:text>'&#xA;</xsl:text>
     </xsl:if>
     <xsl:text>index: '</xsl:text>

--- a/xsl/dita2html.xsl
+++ b/xsl/dita2html.xsl
@@ -26,19 +26,19 @@
     <xsl:text>layout: </xsl:text>
     <xsl:apply-templates select="." mode="jekyll-layout"/>
     <xsl:text>&#xA;</xsl:text>
-    <xsl:text>title: "</xsl:text>
+    <xsl:text>title: '</xsl:text>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="text-only"/>
-    <xsl:text>"&#xA;</xsl:text>
-    <xsl:text>description: "</xsl:text>
+    <xsl:text>'&#xA;</xsl:text>
+    <xsl:text>description: '</xsl:text>
     <xsl:apply-templates select="*[contains(@class, ' topic/shortdesc ')]" mode="text-only"/>
-    <xsl:text>"&#xA;</xsl:text>
-    <xsl:text>index: "</xsl:text>
+    <xsl:text>'&#xA;</xsl:text>
+    <xsl:text>index: '</xsl:text>
     <xsl:value-of select="concat($PATH2PROJ, 'toc', $OUTEXT)"/>
-    <xsl:text>"&#xA;</xsl:text>
+    <xsl:text>'&#xA;</xsl:text>
     <xsl:if test="normalize-space($commit)">
-      <xsl:text>commit: "</xsl:text>
+      <xsl:text>commit: '</xsl:text>
       <xsl:value-of select="normalize-space($commit)"/>
-      <xsl:text>"&#xA;</xsl:text>
+      <xsl:text>'&#xA;</xsl:text>
     </xsl:if>
     <xsl:if test="(/* | /*/*[contains(@class, ' topic/title ')])[tokenize(@outputclass, '\s+') = 'generated']">
       <xsl:text>generated: true</xsl:text>

--- a/xsl/dita2html.xsl
+++ b/xsl/dita2html.xsl
@@ -36,9 +36,9 @@
       <xsl:text>description: '</xsl:text>
       <xsl:for-each select="$shortdescs">
         <xsl:if test="position() ne 1">
-          <xsl:text> </text>
+          <xsl:text> </xsl:text>
         </xsl:if>
-        <xsl:apply-templates select=". mode="text-only"/>
+        <xsl:apply-templates select="." mode="text-only"/>
       </xsl:for-each>
       <xsl:text>'&#xA;</xsl:text>
     </xsl:if>

--- a/xsl/dita2html.xsl
+++ b/xsl/dita2html.xsl
@@ -29,6 +29,9 @@
     <xsl:text>title: "</xsl:text>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="text-only"/>
     <xsl:text>"&#xA;</xsl:text>
+    <xsl:text>description: "</xsl:text>
+    <xsl:apply-templates select="*[contains(@class, ' topic/shortdesc ')]" mode="text-only"/>
+    <xsl:text>"&#xA;</xsl:text>
     <xsl:text>index: "</xsl:text>
     <xsl:value-of select="concat($PATH2PROJ, 'toc', $OUTEXT)"/>
     <xsl:text>"&#xA;</xsl:text>

--- a/xsl/dita2html.xsl
+++ b/xsl/dita2html.xsl
@@ -29,9 +29,11 @@
     <xsl:text>title: '</xsl:text>
     <xsl:apply-templates select="*[contains(@class, ' topic/title ')]" mode="text-only"/>
     <xsl:text>'&#xA;</xsl:text>
-    <xsl:text>description: '</xsl:text>
-    <xsl:apply-templates select="*[contains(@class, ' topic/shortdesc ')]" mode="text-only"/>
-    <xsl:text>'&#xA;</xsl:text>
+    <xsl:if test="*[contains(@class, ' topic/shortdesc ')]">
+      <xsl:text>description: '</xsl:text>
+      <xsl:apply-templates select="*[contains(@class, ' topic/shortdesc ')]" mode="text-only"/>
+      <xsl:text>'&#xA;</xsl:text>
+    </xsl:if>
     <xsl:text>index: '</xsl:text>
     <xsl:value-of select="concat($PATH2PROJ, 'toc', $OUTEXT)"/>
     <xsl:text>'&#xA;</xsl:text>


### PR DESCRIPTION
Our site plugin is currently designed in a way that does not preserve metadata from individual pages, as a common layout template is used for all pages, so the metadata propagated to the `<head>` element in default HTML5 output is lost when generating site output.

Currently, page titles are preserved with the code on [dita2html.xsl#L29-L30](https://github.com/dita-ot/org.dita-ot.html/blob/feature/no-commit-meta/xsl/dita2html.xsl#L29-L30).

For SEO purposes, we should at least preserve the `<shortdesc>` information in `<meta name="description" content="…"/>`
